### PR TITLE
Add fpdf to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,5 @@ beautifulsoup4
 pymupdf
 werkzeug
 
+
+fpdf


### PR DESCRIPTION
## Summary
- include `fpdf` in the dependencies list

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement fpdf)*
- `python Tests/Teste_Ordenacao.py` *(fails: ModuleNotFoundError: No module named 'fpdf')*

------
https://chatgpt.com/codex/tasks/task_e_688d092c80b08325830e93dc4a67c158