### PR TITLE
Implement SQLite-based read tracking

### DIFF
--- a/db.py
+++ b/db.py
@@ -1,0 +1,37 @@
+import sqlite3
+from flask import current_app, g
+
+
+def get_db():
+    if 'db' not in g:
+        g.db = sqlite3.connect(
+            current_app.config['DATABASE'],
+            detect_types=sqlite3.PARSE_DECLTYPES
+        )
+        g.db.row_factory = sqlite3.Row
+    return g.db
+
+
+def close_db(e=None):
+    db = g.pop('db', None)
+    if db is not None:
+        db.close()
+
+
+def init_db(app):
+    with app.app_context():
+        db = get_db()
+        db.execute(
+            "CREATE TABLE IF NOT EXISTS users (id INTEGER PRIMARY KEY AUTOINCREMENT, username TEXT UNIQUE)"
+        )
+        db.execute(
+            """CREATE TABLE IF NOT EXISTS reads (
+                    user_id INTEGER,
+                    manga TEXT,
+                    chapter TEXT,
+                    PRIMARY KEY (user_id, manga, chapter),
+                    FOREIGN KEY(user_id) REFERENCES users(id)
+                )"""
+        )
+        db.commit()
+

--- a/templates/biblioteca.html
+++ b/templates/biblioteca.html
@@ -7,6 +7,11 @@
 </head>
 <body>
   <h1>Biblioteca</h1>
+  {% if g.user %}
+    <p>Usuário: {{ g.user['username'] }} | <a href="{{ url_for('logout') }}">Sair</a></p>
+  {% else %}
+    <p><a href="{{ url_for('login') }}">Login</a></p>
+  {% endif %}
   <div class="manga-grid" id="mangaGrid">
     {% for item in pastas %}
     <div class="manga-card" data-nome="{{ item.nome | lower }}" id="manga-card-{{ item.nome | replace(' ', '_') }}">

--- a/templates/index.html
+++ b/templates/index.html
@@ -10,6 +10,12 @@
     <header>
         <h1>Criador e Leitor de Quadrinhos e Mangás</h1>
         <button class="toggle-btn">Alternar Modo</button>
+        {% if g.user %}
+            <span>Olá, {{ g.user['username'] }}!</span>
+            <a href="{{ url_for('logout') }}">Sair</a>
+        {% else %}
+            <a href="{{ url_for('login') }}">Login</a>
+        {% endif %}
     </header>
 
     <main class="grid-container">

--- a/templates/lista_pdfs.html
+++ b/templates/lista_pdfs.html
@@ -7,6 +7,11 @@
 </head>
 <body>
   <h1>Capítulos de {{ nome_pasta }}</h1>
+  {% if g.user %}
+    <p>Usuário: {{ g.user['username'] }} | <a href="{{ url_for('logout') }}">Sair</a></p>
+  {% else %}
+    <p><a href="{{ url_for('login') }}">Login</a></p>
+  {% endif %}
   <a class="back-link" href="{{ url_for('biblioteca') }}">← Voltar para a biblioteca</a>
 
   <div class="manga-grid">
@@ -14,8 +19,7 @@
     <div class="manga-card-container" id="capitulo-container-{{ arq.replace('.pdf', '') | replace(' ', '_') }}"> {# Adiciona um ID ao container do card #}
       <a href="{{ url_for('visualizar_pdf', manga=nome_pasta, arquivo=arq) }}"
          class="manga-card {% if arq in lidos %}lido{% endif %}"
-         target="_blank"
-         onclick="marcarComoLido('{{ nome_pasta }}', '{{ arq }}')">
+         target="_blank">
         <h2>{{ arq.replace('.pdf', '') }}</h2>
         <label style="display:flex; align-items:center; justify-content:center; gap:6px; font-size: 0.9em; margin: 6px 0;">
           <input type="checkbox" onchange="toggleLido('{{ nome_pasta }}', '{{ arq }}', this.checked)"> Marcar como lido
@@ -37,83 +41,33 @@
   </div>
 
   <script>
-  function marcarComoLido(manga, capitulo) {
-    const key = "lidos_" + manga;
-    let lidos = JSON.parse(localStorage.getItem(key)) || [];
-    if (!lidos.includes(capitulo)) {
-      lidos.push(capitulo);
-      localStorage.setItem(key, JSON.stringify(lidos));
-    }
+  function toggleLido(manga, capitulo, marcado) {
+    fetch('/toggle_lido', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ manga: manga, capitulo: capitulo, lido: marcado })
+    });
+
+    document.querySelectorAll('.manga-card').forEach(card => {
+      const h2Element = card.querySelector('h2');
+      if (h2Element) {
+        const cardCapituloNome = h2Element.textContent.trim() + '.pdf';
+        if (cardCapituloNome === capitulo) {
+          card.classList.toggle('lido', marcado);
+          if (marcado && !card.querySelector('.lido-badge')) {
+            const badge = document.createElement('div');
+            badge.className = 'lido-badge';
+            badge.textContent = 'Lido';
+            card.appendChild(badge);
+          } else if (!marcado && card.querySelector('.lido-badge')) {
+            card.querySelector('.lido-badge').remove();
+          }
+        }
+      }
+    });
   }
 
-  function toggleLido(manga, capitulo, marcado) {
-    const key = "lidos_" + manga;
-    let lidos = JSON.parse(localStorage.getItem(key)) || [];
-    if (marcado && !lidos.includes(capitulo)) {
-      lidos.push(capitulo);
-    } else if (!marcado && lidos.includes(capitulo)) {
-      lidos = lidos.filter(item => item !== capitulo);
-    }
-    localStorage.setItem(key, JSON.stringify(lidos));
-    
-    // Bloco movido para DENTRO da função toggleLido
-    // Atualiza a classe lido no card correspondente
-    document.querySelectorAll(".manga-card").forEach(card => {
-      const h2Element = card.querySelector("h2");
-      if (h2Element) { // Adicionada verificação para segurança
-        const cardCapituloNome = h2Element.textContent.trim() + ".pdf";
-        if (cardCapituloNome === capitulo) { // 'capitulo' e 'marcado' são os parâmetros da função toggleLido
-          card.classList.toggle("lido", marcado);
-          if (marcado && !card.querySelector(".lido-badge")) {
-            const badge = document.createElement("div");
-            badge.className = "lido-badge";
-            badge.textContent = "Lido";
-            card.appendChild(badge);
-          } else if (!marcado && card.querySelector(".lido-badge")) {
-            const badgeElement = card.querySelector(".lido-badge");
-            if (badgeElement) { // Adicionada verificação
-                badgeElement.remove();
-            }
-          }
-        }
-      }
-    });
-  } // Fim da função toggleLido
-
-  document.addEventListener("DOMContentLoaded", () => {
-    // Configuração inicial dos checkboxes e badges ao carregar a página
-    document.querySelectorAll(".manga-card").forEach(card => {
-      const checkbox = card.querySelector("input[type=checkbox]");
-      const titleElement = card.querySelector("h2"); // Pega o elemento h2
-      if (checkbox && titleElement) { // Verifica se ambos os elementos existem
-        const title = titleElement.innerText.trim();
-        const manga = "{{ nome_pasta }}";
-        const key = "lidos_" + manga;
-        const lidos = JSON.parse(localStorage.getItem(key)) || [];
-        checkbox.checked = lidos.includes(title + ".pdf");
-      }
-    });
-
-    document.querySelectorAll(".manga-card").forEach(card => {
-      const titleElement = card.querySelector("h2");
-      if (titleElement) { // Verifica se o elemento de título existe
-        const title = titleElement.innerText.trim();
-        const manga = "{{ nome_pasta }}";
-        const key = "lidos_" + manga;
-        const lidos = JSON.parse(localStorage.getItem(key)) || [];
-        if (lidos.includes(title + ".pdf")) {
-          card.classList.add("lido");
-          if (!card.querySelector(".lido-badge")) {
-            const badge = document.createElement("div");
-            badge.className = "lido-badge";
-            badge.textContent = "Lido";
-            card.appendChild(badge);
-          }
-        }
-      }
-    });
-
-    // Adiciona listeners para os botões de exclusão
+  document.addEventListener('DOMContentLoaded', () => {
     document.querySelectorAll('.btn-excluir-capitulo').forEach(button => {
       button.addEventListener('click', function() {
         const mangaNome = this.dataset.manga;
@@ -122,7 +76,7 @@
 
         if (confirm(`Tem certeza que deseja excluir o capítulo "${arquivoNome.replace('.pdf', '')}" de "${mangaNome}"? Esta ação não pode ser desfeita.`)) {
           fetch(`/excluir_capitulo/${encodeURIComponent(mangaNome)}/${encodeURIComponent(arquivoNome)}`, {
-            method: 'DELETE',
+            method: 'DELETE'
           })
           .then(response => response.json())
           .then(data => {
@@ -131,12 +85,6 @@
               const cardElement = document.getElementById(cardContainerId);
               if (cardElement) {
                 cardElement.remove();
-              }
-              const key = "lidos_" + mangaNome;
-              let lidos = JSON.parse(localStorage.getItem(key)) || [];
-              if (lidos.includes(arquivoNome)) {
-                lidos = lidos.filter(item => item !== arquivoNome);
-                localStorage.setItem(key, JSON.stringify(lidos));
               }
             } else {
               alert('Erro ao excluir capítulo: ' + data.message);
@@ -149,7 +97,7 @@
         }
       });
     });
-  }); // Fim do DOMContentLoaded
+  });
 </script>
 </body>
 </html>

--- a/templates/login.html
+++ b/templates/login.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="pt-br">
+<head>
+    <meta charset="UTF-8">
+    <title>Login</title>
+</head>
+<body>
+    <h1>Login</h1>
+    <form method="post">
+        <label for="username">Nome de usuário:</label>
+        <input type="text" name="username" required>
+        <button type="submit">Entrar</button>
+    </form>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add SQLite helper in `db.py`
- initialize db and user session tracking in `main.py`
- add login/logout routes and protect library pages
- persist chapter read status and update templates
- create new login page

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688d092a80f0832584e5501053bc1845