### PR TITLE
Fix template lookup for Flask app

### DIFF
--- a/comic_creator/__init__.py
+++ b/comic_creator/__init__.py
@@ -1,14 +1,20 @@
-from flask import Flask
+from flask import Flask, render_template
 from .config import Config
 
 
 def create_app(config_class=Config):
-    app = Flask(__name__)
+    app = Flask(
+        __name__, template_folder="../templates", static_folder="../static"
+    )
     app.config.from_object(config_class)
     config_class.init_app(app)
 
     from .routes import bp
     app.register_blueprint(bp)
+
+    @app.route("/login")
+    def login():
+        return render_template("login.html")
 
     return app
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -58,7 +58,7 @@
                 <input type="number" name="capitulo" value="1" required />
                 <button type="submit" name="acao" value="baixar_manual">Baixar e Gerar PDF</button>
             </form>
-            <form action="{{ url_for('biblioteca') }}" method="get">
+            <form action="{{ url_for('main.biblioteca') }}" method="get">
                 <button type="submit">Acessar Biblioteca</button>
             </form>
             {% with messages = get_flashed_messages(with_categories=true) %}


### PR DESCRIPTION
## Summary
- Configure Flask app to load project-level templates and static assets
- Provide a simple `/login` route so existing links resolve
- Update index template to reference the blueprint-scoped library route

## Testing
- `pytest -q` *(fails: 4 tests, unrelated to template lookup)*
- `python - <<'PY'
from comic_creator import create_app
app=create_app()
client=app.test_client()
resp=client.get('/')
print('status', resp.status_code)
print(resp.data.decode('utf-8')[:200])
PY`


------
https://chatgpt.com/codex/tasks/task_e_688f71c98f5c8325a72a5928cdb4e9ec