### PR TITLE
fix(library): limpa cache do React Query ao trocar de usuário

### DIFF
--- a/frontend/main.jsx
+++ b/frontend/main.jsx
@@ -4,7 +4,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import App from './App.jsx';
 import './index.css';
 
-const queryClient = new QueryClient({
+export const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
       staleTime: 1000 * 30,      // dados frescos por 30s

--- a/frontend/src/contexts/AuthContext.jsx
+++ b/frontend/src/contexts/AuthContext.jsx
@@ -1,5 +1,6 @@
 import React, { createContext, useContext, useState, useEffect } from "react";
 import { apiService as api, api as axiosInstance } from "../services/api";
+import { queryClient } from "../../main";
 
 const AuthContext = createContext(null);
 
@@ -41,6 +42,7 @@ export function AuthProvider({ children }) {
     localStorage.setItem("access_token", access_token);
     localStorage.setItem("refresh_token", refresh_token);
     localStorage.setItem("user", JSON.stringify(user));
+    queryClient.clear();
     setUser(user);
     return user;
   };
@@ -51,17 +53,19 @@ export function AuthProvider({ children }) {
     localStorage.setItem("access_token", access_token);
     localStorage.setItem("refresh_token", refresh_token);
     localStorage.setItem("user", JSON.stringify(user));
+    queryClient.clear();
     setUser(user);
     return user;
   };
 
   const logout = async () => {
     const refresh_token = localStorage.getItem("refresh_token");
-    try { 
-        if (refresh_token) await api.logout(refresh_token); 
+    try {
+        if (refresh_token) await api.logout(refresh_token);
     } catch (e) {
         console.error("Logout error", e);
     }
+    queryClient.clear();
     localStorage.removeItem("access_token");
     localStorage.removeItem("refresh_token");
     localStorage.removeItem("user");

--- a/frontend/src/hooks/useChapters.js
+++ b/frontend/src/hooks/useChapters.js
@@ -2,12 +2,15 @@ import { useState, useMemo } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useAlert } from './useAlert';
 import { apiService as api } from '../services/api';
+import { useAuth } from '../contexts/AuthContext';
 
 const ITEMS_PER_PAGE = 20;
 
 export function useChapters(mangaName) {
   const { alert, showAlert } = useAlert(4000);
   const queryClient = useQueryClient();
+  const { user } = useAuth();
+  const userId = user?.id;
 
   const [sortOrder, setSortOrder] = useState('asc');
   const [currentPage, setCurrentPage] = useState(1);
@@ -15,7 +18,7 @@ export function useChapters(mangaName) {
 
   // ── Fetch dos capítulos ───────────────────────────────────────────────────
   const { data: chapters = [], isLoading: loading } = useQuery({
-    queryKey: ['chapters', mangaName, sortOrder],
+    queryKey: ['chapters', userId, mangaName, sortOrder],
     queryFn: () =>
       api.getChapters(mangaName, sortOrder).then(res => {
         const lista = res.data?.chapters ?? res.data?.capitulos ?? [];
@@ -56,7 +59,7 @@ export function useChapters(mangaName) {
     onMutate: (filename) => setDeletingFile(filename),
     onSuccess: (res, filename) => {
       if (res.status === 'success') {
-        queryClient.setQueryData(['chapters', mangaName, sortOrder], (old = []) =>
+        queryClient.setQueryData(['chapters', userId, mangaName, sortOrder], (old = []) =>
           old.filter(c => c.filename !== filename)
         );
         showAlert(res.data?.message || 'Capítulo excluído!');
@@ -73,7 +76,7 @@ export function useChapters(mangaName) {
     mutationFn: (filename) => api.toggleLido(mangaName, filename),
     onSuccess: (res, filename) => {
       if (res.status === 'success') {
-        queryClient.setQueryData(['chapters', mangaName, sortOrder], (old = []) =>
+        queryClient.setQueryData(['chapters', userId, mangaName, sortOrder], (old = []) =>
           old.map(c =>
             c.filename === filename ? { ...c, read: res.data?.lido } : c
           )

--- a/frontend/src/hooks/useLibrary.js
+++ b/frontend/src/hooks/useLibrary.js
@@ -2,19 +2,22 @@ import { useState, useMemo } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useAlert } from './useAlert';
 import { apiService as api } from '../services/api';
+import { useAuth } from '../contexts/AuthContext';
 
 const ITEMS_PER_PAGE = 18;
 
 export function useLibrary() {
   const { alert, showAlert } = useAlert(4000);
   const queryClient = useQueryClient();
+  const { user } = useAuth();
+  const userId = user?.id;
 
   const [search, setSearch] = useState('');
   const [currentPage, setCurrentPage] = useState(1);
 
   // ── Fetch da biblioteca ───────────────────────────────────────────────────
   const { data: mangas = [], isLoading: loading } = useQuery({
-    queryKey: ['library'],
+    queryKey: ['library', userId],
     queryFn: () => api.getLibrary().then(res => res.data ?? []),
   });
 
@@ -49,7 +52,7 @@ export function useLibrary() {
     onSuccess: (res, nomeManga) => {
       if (res.status === 'success') {
         // Atualiza cache sem refetch
-        queryClient.setQueryData(['library'], (old = []) =>
+        queryClient.setQueryData(['library', userId], (old = []) =>
           old.filter(m => m.nome !== nomeManga)
         );
         showAlert(`"${nomeManga}" excluído com sucesso.`);
@@ -66,7 +69,7 @@ export function useLibrary() {
     onSuccess: (res, { nomeManga }) => {
       if (res.status === 'success') {
         // Atualiza a capa no cache sem refetch
-        queryClient.setQueryData(['library'], (old = []) =>
+        queryClient.setQueryData(['library', userId], (old = []) =>
           old.map(m =>
             m.nome === nomeManga
               ? { ...m, tem_capa: true, capa_url: res.data?.capa_url ?? m.capa_url }

--- a/frontend/src/hooks/useUrls.js
+++ b/frontend/src/hooks/useUrls.js
@@ -1,15 +1,18 @@
 import { useState, useEffect } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { apiService as api } from '../services/api';
+import { useAuth } from '../contexts/AuthContext';
 
 export function useUrls() {
   const queryClient = useQueryClient();
+  const { user } = useAuth();
+  const userId = user?.id;
   const [selectedManga, setSelectedManga] = useState('');
   const [baseUrl, setBaseUrl] = useState('');
 
   // ── Fetch das URLs salvas ─────────────────────────────────────────────────
   const { data: urls = {} } = useQuery({
-    queryKey: ['urls'],
+    queryKey: ['urls', userId],
     queryFn: () => api.getUrls().then(res => res.data ?? {}),
   });
 
@@ -25,7 +28,7 @@ export function useUrls() {
     mutationFn: ({ nome, url }) => api.saveUrl(nome, url),
     onSuccess: (res, { nome, url }) => {
       if (res.status === 'success') {
-        queryClient.setQueryData(['urls'], (old = {}) => ({ ...old, [nome]: url }));
+        queryClient.setQueryData(['urls', userId], (old = {}) => ({ ...old, [nome]: url }));
       }
     },
   });
@@ -35,7 +38,7 @@ export function useUrls() {
     mutationFn: (nome) => api.removeUrl(nome),
     onSuccess: (res, nome) => {
       if (res.status === 'success') {
-        queryClient.setQueryData(['urls'], (old = {}) => {
+        queryClient.setQueryData(['urls', userId], (old = {}) => {
           const updated = { ...old };
           delete updated[nome];
           return updated;


### PR DESCRIPTION
Ao fazer login, logout ou register, o cache do React Query é limpo para que cada usuário veja apenas sua própria biblioteca e URLs. As query keys também passaram a incluir o userId como prefixo, garantindo isolamento total mesmo que o clear seja adiado.